### PR TITLE
Added serial reads to flush spurious output from sensor

### DIFF
--- a/SD_ZH03B.cpp
+++ b/SD_ZH03B.cpp
@@ -180,6 +180,11 @@ void SD_ZH03B::setQandAmode(void) {
   _currentMode = QA_MODE;
   _sizeFrame = SIZEOF_QA_FRAME;
   _sendCmd( 0x78, 0x41, 0x46 );
+ 
+  delay(100);
+  while(  _serial.available() ) { 
+    _serial.read();
+  } 
 }
 
 
@@ -192,6 +197,11 @@ void SD_ZH03B::setInitiativeMode(void) {  // default mode
   	_sizeFrame = ZH06_SIZEOF_IU_FRAME;
 	
   _sendCmd( 0x78, 0x40, 0x47 );
+
+  delay(100);  
+  while(  _serial.available() ) {
+    _serial.read();
+  } 
 }
 
 
@@ -215,14 +225,33 @@ bool SD_ZH03B::_getCmdConfirmation(void) {
   
   _serial.readBytes( _unionFrame.buffer, 9 );  // read the response to a buffer
 
-  // check up the received response
-  if( _unionFrame.buffer[1] == 0xA7 && _unionFrame.buffer[2] == 0x01 && _unionFrame.buffer[8] == 0x58 )
-    return true;
+#ifdef DEBUG
+    Serial.println("Command confirmation");
+    for( uint8_t i = 0; i < 9; i++ ) {
+      Serial.print( _unionFrame.buffer[i], HEX); Serial.print( ":");
+    }    
+    Serial.println();
+#endif
 
+  // check up the received response
+  if( _unionFrame.buffer[1] == 0xA7 && _unionFrame.buffer[2] == 0x01 && _unionFrame.buffer[8] == 0x58 ){
+    return true;
+  }  
+
+  Serial.println("Command confirmation invalid:");
+  for( uint8_t i = 0; i < 9; i++ ) {
+    Serial.print( _unionFrame.buffer[i], HEX); Serial.print( ":");
+  }    
+  Serial.println();  
+    
   return false;
 }
 
 void SD_ZH03B::_sendCmd(const uint8_t ch1, const uint8_t ch2, const uint8_t ch3) {
+
+  while(  _serial.available() ) {
+    _serial.read();
+  }  
   _serial.flush(); // clear buffer
 
   // send command header

--- a/SD_ZH03B.cpp
+++ b/SD_ZH03B.cpp
@@ -162,6 +162,14 @@ bool SD_ZH03B::readData(void) {
   return true;
 }
 
+int SD_ZH03B::RX_flush(void){
+  delay(100);  
+  int spurious_count;  
+  for(spurious_count = 0;  _serial.available(); ++spurious_count ) {
+     _serial.read();
+  } 
+  return spurious_count;
+}
 
 void SD_ZH03B::setMode( const mode_t _mode ) {
   switch( _mode ) {  
@@ -181,10 +189,7 @@ void SD_ZH03B::setQandAmode(void) {
   _sizeFrame = SIZEOF_QA_FRAME;
   _sendCmd( 0x78, 0x41, 0x46 );
  
-  delay(100);
-  while(  _serial.available() ) { 
-    _serial.read();
-  } 
+  RX_flush();
 }
 
 
@@ -198,10 +203,7 @@ void SD_ZH03B::setInitiativeMode(void) {  // default mode
 	
   _sendCmd( 0x78, 0x40, 0x47 );
 
-  delay(100);  
-  while(  _serial.available() ) {
-    _serial.read();
-  } 
+  RX_flush();
 }
 
 
@@ -249,10 +251,8 @@ bool SD_ZH03B::_getCmdConfirmation(void) {
 
 void SD_ZH03B::_sendCmd(const uint8_t ch1, const uint8_t ch2, const uint8_t ch3) {
 
-  while(  _serial.available() ) {
-    _serial.read();
-  }  
   _serial.flush(); // clear buffer
+  RX_flush();
 
   // send command header
   _serial.write((uint8_t)0xFF); 

--- a/SD_ZH03B.h
+++ b/SD_ZH03B.h
@@ -139,6 +139,13 @@ enum type_t : uint8_t {
   uint16_t getPM10_0(void) const {
     return _currentMode == IU_MODE ? _unionFrame.ZH03_IUframe.concPM10_0 : _unionFrame.ZHxx_QAframe.concPM10_0;
   }
+  
+/**
+*  @brief read spurious data on RX before sending  
+*  @note  unpredicatble a sensor may havesent spurious data,which can confuse later data reads
+*  @return nunmber of spurious bytes read */
+
+int RX_flush(void);
 
 #define ZH03_SIZEOF_IU_FRAME 24
 #define ZH06_SIZEOF_IU_FRAME 32


### PR DESCRIPTION
Used library to get Winsen ZH07 device working. Input and output are the same as the ZH06 . Spurious output from the sensor made  sleep, wake and other commands fail unpredictably. Added serial reads to flush such unexpected sensor inputs